### PR TITLE
move alembic.ini outside

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = migrations
+script_location = anet_api/db/migrations
 file_template = %%(year)d%%(month).2d%%(day).2d%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s


### PR DESCRIPTION
Move alembic.ini to root so that alembic commands can be run without CD-ing into lower level directories (could not get the `--config` arg to work in the CLI so shortcutting the solution)